### PR TITLE
Add fixers and more output

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,21 +1,35 @@
-vis:command_register("lint", function()
-	local linters = {}
-	linters["bash"] = "shellcheck -"
-	linters["lua"] = "luacheck --no-color -"
-	linters["man"] = "mandoc -T lint"
+linters = {}
+linters["bash"] = {"shellcheck -"}
+linters["json"] = {"jq"}
+linters["lua"] = {"luacheck --no-color -"}
+linters["man"] = {"mandoc -T lint"}
+linters["python"] = {"ruff", "mypy --strict"}
 
-	local cmd = linters[vis.win.syntax]
-	if cmd == nil then
-		vis:info(vis.win.syntax .. ": linter not defined")
+-- Clear vis:message window before running?
+run_actions_on_file = function(action, actions, file)
+	local cmds = actions[vis.win.syntax]
+	if cmds == nil or #cmds == 0 then
+		vis:info(action  .. " not defined for " .. vis.win.syntax)
 		return false
 	end
+	for i, cmd in ipairs(cmds) do
+		vis:message("$ " .. cmd .. "\n")
+		local _, ostr, estr = vis:pipe(file, {start = 0, finish = file.size}, cmd)
 
-	local file = vis.win.file
-	local _, ostr, estr = vis:pipe(file, {start = 0, finish = file.size}, cmd)
-	if estr then
-		vis:message(estr)
-		return false
+		if ostr == nil and estr == nil then
+			vis:message("[no output]")
+		else
+			vis:message((ostr or "") .. (estr or ""))
+		end
+		vis:message("\n")
+
+		if estr then
+			return false
+		end
 	end
-	vis:message(ostr)
 	return true
+end
+
+vis:command_register("lint", function(argv, force, win, selection, range)
+	return run_actions_on_file('linters', linters, win.file)
 end, "Lint the current file and display output in the message window")

--- a/init.lua
+++ b/init.lua
@@ -25,33 +25,47 @@ fixers["rust"] = {"rustfmt"}
 run_actions_on_file = function(action, actions, file, modify)
 	local cmds = actions[vis.win.syntax]
 	if cmds == nil or #cmds == 0 then
-		vis:info(action  .. " not defined for " .. vis.win.syntax)
+		vis:info(action
+			.. " not defined for vis.win.syntax="
+			.. (vis.win.syntax or "undefined")
+			.. " in file "
+			.. (file.name or "unnamed file"))
 		return false
 	end
+	-- Print this for clarity and separate different outputs in the vis:message buffer
+	local header = "--- " .. action .. ": "
+	vis:message(header .. "running " .. action .. " (" .. os.date() .. ")")
+	local all_succeeded = true
 	for i, cmd in ipairs(cmds) do
-		vis:message("$ " .. cmd .. "\n")
-		local _, ostr, estr = vis:pipe(file, {start = 0, finish = file.size}, cmd)
+		vis:message(header .. "piping "
+			.. (file.name or "unnamed file")
+			.. " to `" .. cmd .. "`")
+		local status, ostr, estr = vis:pipe(file, {start = 0, finish = file.size}, cmd)
 
-		if ostr == nil and estr == nil then
-			vis:message("[no output]")
-		else
+		if ostr ~= nil or estr ~= nil then
 			if (modify and ostr) then
 				local pos = vis.win.selection.pos
 				file:delete(0, file.size)
 				file:insert(0, ostr)
 				vis.win.selection.pos = pos
 			else
-				vis:message(ostr or "")
+				if ostr then vis:message(ostr) end
 			end
-			vis:message(estr or "")
+			if estr then vis:message(estr) end
+			vis:redraw()
 		end
-		vis:message("\n")
 
-		if estr then
-			return false
+		if status then
+			all_succeeded = false
+			-- Exit early if any fixer fails as indicated by the exit status
+			if modify then
+				vis:message("Fixer failed with status code " .. status)
+				return false
+			end
 		end
 	end
-	return true
+	vis:message(header .. "done")
+	return all_succeeded
 end
 
 vis:command_register("lint", function(argv, force, win, selection, range)

--- a/init.lua
+++ b/init.lua
@@ -4,10 +4,12 @@ linters["json"] = {"jq"}
 linters["lua"] = {"luacheck --no-color -"}
 linters["man"] = {"mandoc -T lint"}
 linters["python"] = {"ruff", "mypy --strict"}
+linters["rust"] = {"cargo check", "cargo clippy"}
 
 fixers = {}
 fixers["json"] = {"jq -c"}
 fixers["python"] = {"black", "isort", "ruff --fix"}
+fixers["rust"] = {"cargo fmt", "cargo clippy --fix"}
 
 -- Clear vis:message window before running?
 run_actions_on_file = function(action, actions, file)

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,10 @@ linters["lua"] = {"luacheck --no-color -"}
 linters["man"] = {"mandoc -T lint"}
 linters["python"] = {"ruff", "mypy --strict"}
 
+fixers = {}
+fixers["json"] = {"jq -c"}
+fixers["python"] = {"black", "isort", "ruff --fix"}
+
 -- Clear vis:message window before running?
 run_actions_on_file = function(action, actions, file)
 	local cmds = actions[vis.win.syntax]
@@ -33,3 +37,7 @@ end
 vis:command_register("lint", function(argv, force, win, selection, range)
 	return run_actions_on_file('linters', linters, win.file)
 end, "Lint the current file and display output in the message window")
+
+vis:command_register("fix", function(argv, force, win, selection, range)
+	return run_actions_on_file('fixers', fixers, win.file)
+end, "Fix the current file and display output in the message window. May modify file.")

--- a/init.lua
+++ b/init.lua
@@ -3,13 +3,23 @@ linters["bash"] = {"shellcheck -"}
 linters["json"] = {"jq"}
 linters["lua"] = {"luacheck --no-color -"}
 linters["man"] = {"mandoc -T lint"}
-linters["python"] = {"ruff", "mypy --strict"}
-linters["rust"] = {"cargo check", "cargo clippy"}
+linters["python"] = {
+	"black --check -",
+	"isort --check -",
+	"pylint --from-stdin stdin_from_vis",
+	"flake8 -",
+	"ruff -",
+	-- The shell must support process substitution
+	-- Try setting vis' shell to "sh" with "set shell sh"
+	-- https://github.com/python/mypy/issues/12235
+	"mypy <(cat)"
+}
+linters["rust"] = {"rustfmt --check", "clippy-driver -"}
 
 fixers = {}
 fixers["json"] = {"jq -c"}
-fixers["python"] = {"black", "isort", "ruff --fix"}
-fixers["rust"] = {"cargo fmt", "cargo clippy --fix"}
+fixers["python"] = {"black -", "isort -", "ruff --fix -"}
+fixers["rust"] = {"rustfmt"}
 
 -- Clear vis:message window before running?
 run_actions_on_file = function(action, actions, file, modify)


### PR DESCRIPTION
This will add more logging, such as printing the command before running it or printing `[no output]`. Also adds the option to add multiple linters per file type.

I also added the ability to run `fixers`, which may modify the file. This can be used for formatters or linters with a `--fix` option, like `ruff --fix` and `orange` for Python, `cargo clippy --fix` for Rust, or `jq -c` for JSON. 