### PR TITLE
Add another example to README and print failure count

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Additional tools for fixing and linting can be added as follows:
 
 	local lint = require("plugins/vis-lint")
 	table.insert(lint.linters["python"], "pylint --from-stdin stdin_from_vis")
+	table.insert(lint.linters["python"], "mypy /dev/stdin")
 
-Note: any added tools must read/write from `stdin`/`stdout`. Some
-programs, like the above example, may need some non standard flags. You
-can also try using `-` or `/dev/stdin` as the input parameter.
+#### Tools must read from `stdin` and output to `stdout`!
+
+Some programs, like the above examples, may need some non standard flags.
+You can also try using `-` or `/dev/stdin` as the input parameter.
 
 ### Overriding The Defaults
 


### PR DESCRIPTION
Hello again.

I added the `mypy <(cat)` example to the README, and I changed init.lua so it prints the total number of failed commands.

Example output for a Python file:

```
--- vis-lint: (Fri Nov  3 18:36:07 2023)
--- piping {ba,z,tc,c}sh/bin/trimdir.py<0,1255> to `black --check -`
All done! ✨ 🍰 ✨
1 file would be left unchanged.

--- piping {ba,z,tc,c}sh/bin/trimdir.py<0,1255> to `isort --check -`
--- piping {ba,z,tc,c}sh/bin/trimdir.py<0,1255> to `pylint --from-stdin visfile`
************* Module visfile
visfile:13:0: C0116: Missing function or method docstring (missing-function-docstring)
visfile:18:0: C0116: Missing function or method docstring (missing-function-docstring)

------------------------------------------------------------------
Your code has been rated at 9.13/10 (previous run: 9.13/10, +0.00)


--- piping {ba,z,tc,c}sh/bin/trimdir.py<0,1255> to `mypy <(cat)`
Success: no issues found in 1 source file

--- 4 commands done, 1 reported a problem
```